### PR TITLE
Fix hard-coded python exe name in __main__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+dist/
 build/
 utilities_internal/
 source/materialxusd.egg-info/

--- a/documents/html/____main_____8py_source.html
+++ b/documents/html/____main_____8py_source.html
@@ -135,13 +135,14 @@ $(function(){initNavTree('____main_____8py_source.html',''); initResizable(true)
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span>    <span class="comment"># Build the command</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span>    cmd = <span class="stringliteral">&#39; &#39;</span>.join(cmdArgs)</div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span>    packageLocation = os.path.dirname(__file__)</div>
-<div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span>    cmd = <span class="stringliteral">&#39;python &#39;</span> + packageLocation + <span class="stringliteral">&#39;/&#39;</span> + cmd</div>
-<div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span> </div>
-<div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span>    <span class="comment"># Run the command</span></div>
-<div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span>    <span class="keywordflow">return</span> subprocess.call(cmd, shell=<span class="keyword">True</span>)</div>
-<div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span> </div>
-<div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="keywordflow">if</span> __name__ == <span class="stringliteral">&#39;__main__&#39;</span>:</div>
-<div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span>    sys.exit(main())</div>
+<div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span>    cmd = sys.executable + <span class="stringliteral">&#39; &#39;</span> + packageLocation + <span class="stringliteral">&#39;/&#39;</span> + cmd</div>
+<div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span>    print(<span class="stringliteral">&#39;Running command:&#39;</span>, cmd)</div>
+<div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span> </div>
+<div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span>    <span class="comment"># Run the command</span></div>
+<div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span>    <span class="keywordflow">return</span> subprocess.call(cmd, shell=<span class="keyword">True</span>)</div>
+<div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span> </div>
+<div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="keywordflow">if</span> __name__ == <span class="stringliteral">&#39;__main__&#39;</span>:</div>
+<div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span>    sys.exit(main())</div>
 </div><!-- fragment --></div><!-- contents -->
 </div><!-- doc-content -->
 <!-- HTML footer for doxygen 1.12.0-->

--- a/documents/html/usd_physically_based_gallery.html
+++ b/documents/html/usd_physically_based_gallery.html
@@ -112,10 +112,383 @@
             <div class="row">
     
             <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Aluminum_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Aluminum_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Aluminum_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Banana_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Banana_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Banana_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Blackboard_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Blackboard_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Blackboard_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Blood_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Blood_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Blood_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        </div><div class="row">
+
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Bone_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Bone_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Bone_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Brass_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Brass_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Brass_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Brick_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Brick_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Brick_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Carrot_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Carrot_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Carrot_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        </div><div class="row">
+
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Car_Paint_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Car_Paint_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Car_Paint_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Charcoal_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Charcoal_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Charcoal_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Chocolate_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Chocolate_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Chocolate_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Chromium_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Chromium_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Chromium_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        </div><div class="row">
+
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Cobalt_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Cobalt_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Cobalt_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Coffee_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Coffee_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Coffee_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Concrete_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Concrete_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Concrete_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Cooking_Oil_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Cooking_Oil_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Cooking_Oil_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        </div><div class="row">
+
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Copper_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Copper_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Copper_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Diamond_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Diamond_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Diamond_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Egg_Shell_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Egg_Shell_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Egg_Shell_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Eye__cornea__OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Eye__cornea__OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Eye__cornea__OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        </div><div class="row">
+
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Eye__lens__OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Eye__lens__OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Eye__lens__OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Eye__sclera__OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Eye__sclera__OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Eye__sclera__OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Gasoline_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Gasoline_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Gasoline_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Glass_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Glass_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Glass_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        </div><div class="row">
+
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Gold_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Gold_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Gold_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Gray_Card_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Gray_Card_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Gray_Card_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Honey_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Honey_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Honey_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Ice_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Ice_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Ice_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        </div><div class="row">
+
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Iron_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Iron_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Iron_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Ketchup_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Ketchup_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Ketchup_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Lead_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Lead_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Lead_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Lemon_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Lemon_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Lemon_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        </div><div class="row">
+
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Marble_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Marble_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Marble_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Mercury_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Mercury_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Mercury_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Milk_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Milk_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Milk_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\MIT_Black_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="MIT_Black_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">MIT_Black_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        </div><div class="row">
+
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Musou_Black_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Musou_Black_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Musou_Black_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Nickel_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Nickel_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Nickel_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Office_Paper_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Office_Paper_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Office_Paper_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Pearl_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Pearl_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Pearl_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        </div><div class="row">
+
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Petroleum_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Petroleum_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Petroleum_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Plastic__Acrylic__OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Plastic__Acrylic__OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Plastic__Acrylic__OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Plastic__PC__OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Plastic__PC__OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Plastic__PC__OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Plastic__PET__OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Plastic__PET__OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Plastic__PET__OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        </div><div class="row">
+
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Plastic__PP__OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Plastic__PP__OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Plastic__PP__OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Plastic__PVC__OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Plastic__PVC__OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Plastic__PVC__OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Platinum_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Platinum_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Platinum_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Polyurethane_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Polyurethane_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Polyurethane_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        </div><div class="row">
+
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Quartz_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Quartz_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Quartz_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Salt_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Salt_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Salt_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Sand_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Sand_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Sand_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Sapphire_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Sapphire_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Sapphire_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        </div><div class="row">
+
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Silicon_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Silicon_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Silicon_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Silver_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Silver_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Silver_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Skin_III_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Skin_III_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Skin_III_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Skin_II_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Skin_II_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Skin_II_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        </div><div class="row">
+
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Skin_IV_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Skin_IV_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Skin_IV_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Skin_I_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Skin_I_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Skin_I_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Skin_VI_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Skin_VI_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Skin_VI_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Skin_V_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Skin_V_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Skin_V_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        </div><div class="row">
+
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Snow_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Snow_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Snow_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Soap_Bubble_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Soap_Bubble_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Soap_Bubble_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Stainless_Steel_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Stainless_Steel_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Stainless_Steel_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Tire_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Tire_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Tire_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        </div><div class="row">
+
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Titanium_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Titanium_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Titanium_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Toner__black__OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Toner__black__OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Toner__black__OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Tungsten_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Tungsten_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Tungsten_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Vanadium_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Vanadium_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Vanadium_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        </div><div class="row">
+
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Water_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Water_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Water_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Whiteboard_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Whiteboard_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Whiteboard_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
+                <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/PhysicallyBasedMaterialX_OPBR\Zinc_OPBR_MAT_PBM_glslfx.png" class="img-fluid" alt="Zinc_OPBR_MAT_PBM_glslfx.png" loading="lazy">
+                <div class="image-name">Zinc_OPBR_MAT_PBM_glslfx.png</div>
+            </div>
+        
+            <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Aluminum_glslfx.png" class="img-fluid" alt="MPB_Aluminum_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Aluminum_glslfx.png</div>
             </div>
-        
+        </div><div class="row">
+
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Banana_glslfx.png" class="img-fluid" alt="MPB_Banana_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Banana_glslfx.png</div>
@@ -130,13 +503,13 @@
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Blood_glslfx.png" class="img-fluid" alt="MPB_Blood_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Blood_glslfx.png</div>
             </div>
-        </div><div class="row">
-
+        
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Bone_glslfx.png" class="img-fluid" alt="MPB_Bone_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Bone_glslfx.png</div>
             </div>
-        
+        </div><div class="row">
+
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Brass_glslfx.png" class="img-fluid" alt="MPB_Brass_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Brass_glslfx.png</div>
@@ -151,13 +524,13 @@
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Carrot_glslfx.png" class="img-fluid" alt="MPB_Carrot_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Carrot_glslfx.png</div>
             </div>
-        </div><div class="row">
-
+        
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Car_Paint_glslfx.png" class="img-fluid" alt="MPB_Car_Paint_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Car_Paint_glslfx.png</div>
             </div>
-        
+        </div><div class="row">
+
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Charcoal_glslfx.png" class="img-fluid" alt="MPB_Charcoal_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Charcoal_glslfx.png</div>
@@ -172,13 +545,13 @@
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Chromium_glslfx.png" class="img-fluid" alt="MPB_Chromium_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Chromium_glslfx.png</div>
             </div>
-        </div><div class="row">
-
+        
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Cobalt_glslfx.png" class="img-fluid" alt="MPB_Cobalt_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Cobalt_glslfx.png</div>
             </div>
-        
+        </div><div class="row">
+
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Coffee_glslfx.png" class="img-fluid" alt="MPB_Coffee_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Coffee_glslfx.png</div>
@@ -193,13 +566,13 @@
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Cooking_Oil_glslfx.png" class="img-fluid" alt="MPB_Cooking_Oil_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Cooking_Oil_glslfx.png</div>
             </div>
-        </div><div class="row">
-
+        
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Copper_glslfx.png" class="img-fluid" alt="MPB_Copper_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Copper_glslfx.png</div>
             </div>
-        
+        </div><div class="row">
+
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Diamond_glslfx.png" class="img-fluid" alt="MPB_Diamond_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Diamond_glslfx.png</div>
@@ -214,13 +587,13 @@
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Eye__cornea__glslfx.png" class="img-fluid" alt="MPB_Eye__cornea__glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Eye__cornea__glslfx.png</div>
             </div>
-        </div><div class="row">
-
+        
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Eye__lens__glslfx.png" class="img-fluid" alt="MPB_Eye__lens__glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Eye__lens__glslfx.png</div>
             </div>
-        
+        </div><div class="row">
+
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Eye__sclera__glslfx.png" class="img-fluid" alt="MPB_Eye__sclera__glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Eye__sclera__glslfx.png</div>
@@ -235,13 +608,13 @@
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Glass_glslfx.png" class="img-fluid" alt="MPB_Glass_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Glass_glslfx.png</div>
             </div>
-        </div><div class="row">
-
+        
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Gold_glslfx.png" class="img-fluid" alt="MPB_Gold_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Gold_glslfx.png</div>
             </div>
-        
+        </div><div class="row">
+
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Gray_Card_glslfx.png" class="img-fluid" alt="MPB_Gray_Card_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Gray_Card_glslfx.png</div>
@@ -256,13 +629,13 @@
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Ice_glslfx.png" class="img-fluid" alt="MPB_Ice_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Ice_glslfx.png</div>
             </div>
-        </div><div class="row">
-
+        
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Iron_glslfx.png" class="img-fluid" alt="MPB_Iron_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Iron_glslfx.png</div>
             </div>
-        
+        </div><div class="row">
+
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Ketchup_glslfx.png" class="img-fluid" alt="MPB_Ketchup_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Ketchup_glslfx.png</div>
@@ -277,13 +650,13 @@
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Lemon_glslfx.png" class="img-fluid" alt="MPB_Lemon_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Lemon_glslfx.png</div>
             </div>
-        </div><div class="row">
-
+        
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Marble_glslfx.png" class="img-fluid" alt="MPB_Marble_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Marble_glslfx.png</div>
             </div>
-        
+        </div><div class="row">
+
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Mercury_glslfx.png" class="img-fluid" alt="MPB_Mercury_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Mercury_glslfx.png</div>
@@ -298,13 +671,13 @@
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_MIT_Black_glslfx.png" class="img-fluid" alt="MPB_MIT_Black_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_MIT_Black_glslfx.png</div>
             </div>
-        </div><div class="row">
-
+        
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Musou_Black_glslfx.png" class="img-fluid" alt="MPB_Musou_Black_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Musou_Black_glslfx.png</div>
             </div>
-        
+        </div><div class="row">
+
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Nickel_glslfx.png" class="img-fluid" alt="MPB_Nickel_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Nickel_glslfx.png</div>
@@ -319,13 +692,13 @@
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Pearl_glslfx.png" class="img-fluid" alt="MPB_Pearl_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Pearl_glslfx.png</div>
             </div>
-        </div><div class="row">
-
+        
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Petroleum_glslfx.png" class="img-fluid" alt="MPB_Petroleum_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Petroleum_glslfx.png</div>
             </div>
-        
+        </div><div class="row">
+
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Plastic__Acrylic__glslfx.png" class="img-fluid" alt="MPB_Plastic__Acrylic__glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Plastic__Acrylic__glslfx.png</div>
@@ -340,13 +713,13 @@
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Plastic__PET__glslfx.png" class="img-fluid" alt="MPB_Plastic__PET__glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Plastic__PET__glslfx.png</div>
             </div>
-        </div><div class="row">
-
+        
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Plastic__PP__glslfx.png" class="img-fluid" alt="MPB_Plastic__PP__glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Plastic__PP__glslfx.png</div>
             </div>
-        
+        </div><div class="row">
+
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Plastic__PVC__glslfx.png" class="img-fluid" alt="MPB_Plastic__PVC__glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Plastic__PVC__glslfx.png</div>
@@ -361,13 +734,13 @@
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Polyurethane_glslfx.png" class="img-fluid" alt="MPB_Polyurethane_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Polyurethane_glslfx.png</div>
             </div>
-        </div><div class="row">
-
+        
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Quartz_glslfx.png" class="img-fluid" alt="MPB_Quartz_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Quartz_glslfx.png</div>
             </div>
-        
+        </div><div class="row">
+
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Salt_glslfx.png" class="img-fluid" alt="MPB_Salt_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Salt_glslfx.png</div>
@@ -382,13 +755,13 @@
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Sapphire_glslfx.png" class="img-fluid" alt="MPB_Sapphire_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Sapphire_glslfx.png</div>
             </div>
-        </div><div class="row">
-
+        
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Silicon_glslfx.png" class="img-fluid" alt="MPB_Silicon_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Silicon_glslfx.png</div>
             </div>
-        
+        </div><div class="row">
+
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Silver_glslfx.png" class="img-fluid" alt="MPB_Silver_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Silver_glslfx.png</div>
@@ -403,13 +776,13 @@
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Skin_II_glslfx.png" class="img-fluid" alt="MPB_Skin_II_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Skin_II_glslfx.png</div>
             </div>
-        </div><div class="row">
-
+        
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Skin_IV_glslfx.png" class="img-fluid" alt="MPB_Skin_IV_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Skin_IV_glslfx.png</div>
             </div>
-        
+        </div><div class="row">
+
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Skin_I_glslfx.png" class="img-fluid" alt="MPB_Skin_I_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Skin_I_glslfx.png</div>
@@ -424,13 +797,13 @@
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Skin_V_glslfx.png" class="img-fluid" alt="MPB_Skin_V_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Skin_V_glslfx.png</div>
             </div>
-        </div><div class="row">
-
+        
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Snow_glslfx.png" class="img-fluid" alt="MPB_Snow_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Snow_glslfx.png</div>
             </div>
-        
+        </div><div class="row">
+
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Soap_Bubble_glslfx.png" class="img-fluid" alt="MPB_Soap_Bubble_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Soap_Bubble_glslfx.png</div>
@@ -445,13 +818,13 @@
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Tire_glslfx.png" class="img-fluid" alt="MPB_Tire_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Tire_glslfx.png</div>
             </div>
-        </div><div class="row">
-
+        
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Titanium_glslfx.png" class="img-fluid" alt="MPB_Titanium_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Titanium_glslfx.png</div>
             </div>
-        
+        </div><div class="row">
+
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Toner__black__glslfx.png" class="img-fluid" alt="MPB_Toner__black__glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Toner__black__glslfx.png</div>
@@ -466,13 +839,13 @@
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Vanadium_glslfx.png" class="img-fluid" alt="MPB_Vanadium_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Vanadium_glslfx.png</div>
             </div>
-        </div><div class="row">
-
+        
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Water_glslfx.png" class="img-fluid" alt="MPB_Water_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Water_glslfx.png</div>
             </div>
-        
+        </div><div class="row">
+
             <div class="col-md-3">
                 <img src="https://kwokcb.github.io/materialxusd/tests/physically_based/stdsurf_materials\MPB_Whiteboard_glslfx.png" class="img-fluid" alt="MPB_Whiteboard_glslfx.png" loading="lazy">
                 <div class="image-name">MPB_Whiteboard_glslfx.png</div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "materialxusd"
-version = "0.25.05"
+version = "0.25.05.1"
 description = "Utilities for MaterialX and USD"
 authors = [
   { name="Bernard Kwok", email="kwokcb@gmail.com" },

--- a/source/materialxusd/__main__.py
+++ b/source/materialxusd/__main__.py
@@ -25,7 +25,8 @@ def main() -> int:
     # Build the command
     cmd = ' '.join(cmdArgs)
     packageLocation = os.path.dirname(__file__)
-    cmd = 'python ' + packageLocation + '/' + cmd
+    cmd = sys.executable + ' ' + packageLocation + '/' + cmd
+    print('Running command:', cmd)
 
     # Run the command
     return subprocess.call(cmd, shell=True)

--- a/utilities/build_publish.sh
+++ b/utilities/build_publish.sh
@@ -1,0 +1,3 @@
+rm -rf dist/ build/ *.egg-info
+py -m build
+twine check dist/*


### PR DESCRIPTION
## Change

- Fix #31 
- Small fix main to use `sys.executable` vs `python` as this can be named differently depedning on install

## Versioning

- Bump version number for next patch release
 